### PR TITLE
use magic instead of mimetype

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 click==3.3
 requests==2.6.0
+python-magic==0.4.6

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
     install_requires=(
         'click',
         'requests',
+        'python-magic',
     ),
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
This commit replaces the very limited mimetype guessing with python-magic.
magic is more accurate and the patch includes guessing the mimetype of stdin without tempfiles via BytesIO.
This change requires python2.6 and introduces python-magic as depency