### PR TITLE
header values must be strings

### DIFF
--- a/bepasty_cli/cli.py
+++ b/bepasty_cli/cli.py
@@ -8,8 +8,6 @@ commandline client for bepasty-server
 
 from __future__ import print_function
 import base64
-from io import BytesIO
-
 import os
 import sys
 
@@ -55,24 +53,24 @@ import requests
     '--insecure',
     help='Disable SSL certificate validation',
     is_flag=True)
-
-def main(token, filename, fname, url, ftype, list_pastes,insecure):
+def main(token, filename, fname, url, ftype, list_pastes, insecure):
     if list_pastes:
-        print_list(token,url,insecure)
+        print_list(token, url, insecure)
     else:
-        upload(token,filename,fname,url,ftype,insecure)
+        upload(token, filename, fname, url, ftype, insecure)
 
-def print_list(token,url,insecure):
+
+def print_list(token, url, insecure):
     from datetime import datetime
     try:
         response = requests.get(
             '{}/apis/rest/items'.format(url),
-            auth=('user', token),verify=(not insecure))
+            auth=('user', token), verify=(not insecure))
     except Exception as e:
         print("Cannot request {}/api/rest/items".format(url))
         print(e)
     try:
-        for k,v in response.json().items():
+        for k, v in response.json().items():
             meta = v['file-meta']
             if not meta:
                 print("{:8}: BROKEN PASTE".format(k))
@@ -84,6 +82,7 @@ def print_list(token,url,insecure):
     except Exception as e:
         print("cannot load json from response: {}".format(e))
         print("Original Response: {}".format(response))
+
 
 def upload(token, filename, fname, url, ftype, insecure):
     """
@@ -106,7 +105,7 @@ def upload(token, filename, fname, url, ftype, insecure):
     first_chunk = fileobj.read(read_size)
     if not ftype:
         mime = magic.Magic(mime=True)
-        ftype= mime.from_buffer(first_chunk).decode()
+        ftype = mime.from_buffer(first_chunk).decode()
 
         if not ftype:
             print('falling back to {}'.format(ftype))

--- a/bepasty_cli/cli.py
+++ b/bepasty_cli/cli.py
@@ -135,11 +135,10 @@ def upload(token, filename, fname, url, ftype, insecure):
         payload = base64.b64encode(raw_data)
 
         headers = {
-            'Content-Range': ('bytes %d-%d/%d' %
-                              (offset, offset + raw_data_size - 1, filesize)),
+            'Content-Range': 'bytes %d-%d/%d' % (offset, offset + raw_data_size - 1, filesize),
             'Content-Type': ftype,
             'Content-Filename': fname,
-            'Content-Length': len(payload),  # rfc 2616 14.16
+            'Content-Length': str(len(payload)),  # rfc 2616 14.16
         }
         if trans_id != '':
             headers['Transaction-ID'] = trans_id


### PR DESCRIPTION
I got the following traceback, because the value of Content-Length wasn't encoded as string:

```
Traceback (most recent call last):
  File "~/v/bepasty-client-cli/bin/bepasty-cli", line 9, in <module>
    load_entry_point('bepasty-client-cli==0.3.0', 'console_scripts', 'bepasty-cli')()
  File "~/v/bepasty-client-cli/local/lib/python2.7/site-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "~/v/bepasty-client-cli/local/lib/python2.7/site-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "~/v/bepasty-client-cli/local/lib/python2.7/site-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "~/v/bepasty-client-cli/local/lib/python2.7/site-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "~/v/bepasty-client-cli/local/lib/python2.7/site-packages/bepasty_cli/cli.py", line 63, in main
    upload(token,filename,fname,url,ftype,insecure)
  File "~/v/bepasty-client-cli/local/lib/python2.7/site-packages/bepasty_cli/cli.py", line 152, in upload
    verify=(not insecure))
  File "~/v/bepasty-client-cli/local/lib/python2.7/site-packages/requests/api.py", line 110, in post
    return request('post', url, data=data, json=json, **kwargs)
  File "~/v/bepasty-client-cli/local/lib/python2.7/site-packages/requests/api.py", line 56, in request
    return session.request(method=method, url=url, **kwargs)
  File "~/v/bepasty-client-cli/local/lib/python2.7/site-packages/requests/sessions.py", line 461, in request
    prep = self.prepare_request(req)
  File "~/v/bepasty-client-cli/local/lib/python2.7/site-packages/requests/sessions.py", line 394, in prepare_request
    hooks=merge_hooks(request.hooks, self.hooks),
  File "~/v/bepasty-client-cli/local/lib/python2.7/site-packages/requests/models.py", line 295, in prepare
    self.prepare_headers(headers)
  File "~/v/bepasty-client-cli/local/lib/python2.7/site-packages/requests/models.py", line 409, in prepare_headers
    check_header_validity(header)
  File "~/v/bepasty-client-cli/local/lib/python2.7/site-packages/requests/utils.py", line 800, in check_header_validity
    "not %s" % (value, type(value)))
requests.exceptions.InvalidHeader: Header value 33336 must be of type str or bytes, not <type 'int'>
```
[Requests docs](http://docs.python-requests.org/en/latest/user/quickstart/#custom-headers) say: "All header values must be a string, bytestring, or unicode. While permitted, it's advised to avoid passing unicode header values."

Whitespace and non-whitespace changes in separate commits.