### PR TITLE
fix ImportError on debian, which has unbundled urllib3 from requests

### DIFF
--- a/bepasty_cli/cli.py
+++ b/bepasty_cli/cli.py
@@ -24,7 +24,10 @@ except ImportError:
 import click
 import magic
 import requests
-from requests.packages.urllib3.exceptions import InsecureRequestWarning
+try:
+    from requests.packages.urllib3.exceptions import InsecureRequestWarning
+except ImportError:
+    from urllib3.exceptions import InsecureRequestWarning
 
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])

--- a/bepasty_cli/cli.py
+++ b/bepasty_cli/cli.py
@@ -27,6 +27,7 @@ import requests
 try:
     from requests.packages.urllib3.exceptions import InsecureRequestWarning
 except ImportError:
+    # Debian has unbundled urllib3 from requests
     from urllib3.exceptions import InsecureRequestWarning
 
 


### PR DESCRIPTION
When using requests provided by the system (not using a virtualenv), on Debian I get
`ImportError: cannot import name InsecureRequestWarning`.

With this commit I can run bepasty-client-cli directly on Debian Jessie by just installing `python-requests`, `python-urllib3` and `python-click`.

